### PR TITLE
u-boot: add separate u-boot-bup-payload recipe

### DIFF
--- a/recipes-bsp/u-boot/u-boot-bup-payload.bb
+++ b/recipes-bsp/u-boot/u-boot-bup-payload.bb
@@ -1,0 +1,56 @@
+DESCRIPTION = "Generates a bootloader update payload for use with nv_update_engine when using U-Boot on tegra186 platforms."
+LICENSE = "MIT"
+
+COMPATIBLE_MACHINE = "(tegra186)"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+inherit nopackages image_types_tegra deploy
+
+deltask do_fetch
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+
+UBOOT_SUFFIX ??= "bin"
+UBOOT_BINARY ?= "u-boot-dtb.${UBOOT_SUFFIX}"
+UBOOT_IMAGE ?= "u-boot-${MACHINE}.${UBOOT_SUFFIX}"
+
+do_deploy() {
+    if [ -n "${UBOOT_CONFIG}" ]
+    then
+        for config in ${UBOOT_MACHINE}; do
+            i=$(expr $i + 1);
+            for type in ${UBOOT_CONFIG}; do
+                j=$(expr $j + 1);
+                if [ $j -eq $i ]
+                then
+		    oe_make_bup_payload ${DEPLOY_DIR_IMAGE}/u-boot-${type}.${UBOOT_SUFFIX}
+                    install -d ${DEPLOYDIR}
+                    install -m 644 ${WORKDIR}/bup-payload/bl_update_payload ${DEPLOYDIR}/u-boot-${type}.${UBOOT_SUFFIX}.bup-payload
+                    cd ${DEPLOYDIR}
+                    ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_IMAGE}-${type}.bup-payload
+                    ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_IMAGE}.bup-payload
+                    ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_BINARY}-${type}.bup-payload
+                    ln -sf u-boot-${type}.${UBOOT_SUFFIX}.bup-payload ${UBOOT_BINARY}.bup-payload
+                fi
+            done
+            unset  j
+        done
+        unset  i
+    else
+	oe_make_bup_payload ${DEPLOY_DIR_IMAGE}/${UBOOT_IMAGE}
+        install -d ${DEPLOYDIR}
+        rm -f ${DEPLOYDIR}/${UBOOT_BINARY}.bup-payload
+        install -m 644 ${WORKDIR}/bup-payload/bl_update_payload ${DEPLOYDIR}/${UBOOT_IMAGE}.bup-payload
+        ln -sf ${UBOOT_IMAGE}.bup-payload ${DEPLOYDIR}/${UBOOT_BINARY}.bup-payload
+    fi
+}
+do_deploy[depends] += "cboot:do_deploy virtual/bootloader:do_deploy virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot"
+do_deploy[depends] += "tegra186-redundant-boot:do_populate_sysroot tegra-bootfiles:do_populate_sysroot nv-tegra-release:do_populate_sysroot"
+addtask deploy before do_build
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/u-boot/u-boot-tegra_2016.07.bb
+++ b/recipes-bsp/u-boot/u-boot-tegra_2016.07.bb
@@ -4,11 +4,7 @@ require recipes-bsp/u-boot/u-boot.inc
 require u-boot-tegra-common-${PV}.inc
 
 PROVIDES += "u-boot"
-DEPENDS += "dtc-native bc-native ${SOC_FAMILY}-flashtools-native tegra-bootfiles nv-tegra-release"
-CBOOTDEP = "virtual/kernel:do_deploy"
-CBOOTDEP_append_tegra186 = " cboot:do_deploy"
-BUPDEPS = ""
-BUPDEPS_tegra186 = "cboot:do_deploy virtual/kernel:do_deploy"
+DEPENDS += "dtc-native bc-native ${SOC_FAMILY}-flashtools-native"
 
 inherit image_types_tegra
 
@@ -32,7 +28,6 @@ uboot_make_bootimg() {
 			    ${STAGING_BINDIR_NATIVE}/${SOC_FAMILY}-flash/mkbootimg \
 			        --kernel ${B}/${config}/${binary} --ramdisk ${B}/initrd --cmdline "" \
 			        --board "${UBOOT_BOOTIMG_BOARD}" --output $f
-			    uboot_bup_payload $f
 			fi
 		    done
 		    unset k
@@ -46,54 +41,11 @@ uboot_make_bootimg() {
 	${STAGING_BINDIR_NATIVE}/${SOC_FAMILY}-flash/mkbootimg \
 	    --kernel ${UBOOT_BINARY}.orig --ramdisk ${B}/initrd --cmdline "" \
 	    --board "${UBOOT_BOOTIMG_BOARD}" --output ${UBOOT_BINARY}
-	uboot_bup_payload ${UBOOT_BINARY}
     fi
 }
 
 do_compile_append() {
     uboot_make_bootimg
-}
-
-uboot_bup_payload() {
-    :
-}
-
-uboot_bup_payload_tegra186() {
-    oe_make_bup_payload ${B}/$1
-    cp ${WORKDIR}/bup-payload/bl_update_payload ${1}.bup-payload
-}
-
-do_compile[depends] += "${BUPDEPS}"
-
-do_deploy_append_tegra186 () {
-    if [ -n "${UBOOT_CONFIG}" ]
-    then
-        for config in ${UBOOT_MACHINE}; do
-            i=$(expr $i + 1);
-            for type in ${UBOOT_CONFIG}; do
-                j=$(expr $j + 1);
-                if [ $j -eq $i ]
-                then
-                    install -d ${DEPLOYDIR}
-                    install -m 644 ${B}/${config}/u-boot-${type}.${UBOOT_SUFFIX} ${DEPLOYDIR}/u-boot-${type}-${PV}-${PR}.${UBOOT_SUFFIX}.bup-payload
-                    cd ${DEPLOYDIR}
-                    ln -sf u-boot-${type}-${PV}-${PR}.${UBOOT_SUFFIX} ${UBOOT_SYMLINK}-${type}.bup-payload
-                    ln -sf u-boot-${type}-${PV}-${PR}.${UBOOT_SUFFIX} ${UBOOT_SYMLINK}.bup-payload
-                    ln -sf u-boot-${type}-${PV}-${PR}.${UBOOT_SUFFIX} ${UBOOT_BINARY}-${type}.bup-payload
-                    ln -sf u-boot-${type}-${PV}-${PR}.${UBOOT_SUFFIX} ${UBOOT_BINARY}.bup-payload
-                fi
-            done
-            unset  j
-        done
-        unset  i
-    else
-        install -d ${DEPLOYDIR}
-        install -m 644 ${B}/${UBOOT_BINARY}.bup-payload ${DEPLOYDIR}/${UBOOT_IMAGE}.bup-payload
-        cd ${DEPLOYDIR}
-        rm -f ${UBOOT_BINARY}.bup-payload ${UBOOT_SYMLINK}.bup-payload
-        ln -sf ${UBOOT_IMAGE}.bup-payload ${UBOOT_SYMLINK}.bup-payload
-        ln -sf ${UBOOT_IMAGE}.bup-payload ${UBOOT_BINARY}.bup-payload
-    fi
 }
 
 do_install_append() {


### PR DESCRIPTION
for generating BUP payloads when using U-Boot. This
breaks a dependency loop among u-boot, the kernel,
and the initramfs when attempting to build a FIT
image.

Note that you must also set TEGRA_INITRAMFS_INITRD to ""
when using FIT images, to avoid another dependency
loop.

(#204)

Signed-off-by: Matt Madison <matt@madison.systems>